### PR TITLE
Fix share poster and QR code not generating on mobile

### DIFF
--- a/app/javascript/controllers/share_controller.js
+++ b/app/javascript/controllers/share_controller.js
@@ -90,7 +90,9 @@ export default class extends Controller {
 
       const dataUrl = await toPng(this.posterTemplateTarget, {
         pixelRatio: 2,
-        backgroundColor: "#ffffff"
+        backgroundColor: "#ffffff",
+        width: 1080,
+        height: 1920
       })
 
       this.previewTarget.src = dataUrl


### PR DESCRIPTION
## Summary
Pass explicit `width: 1080` and `height: 1920` into `toPng()` in the share controller so poster generation no longer depends on the hidden template's computed size.

## Problem
On mobile, the poster template lives inside a zero-size container (`width: 0; height: 0`). Many mobile browsers report zero `clientWidth`/`clientHeight` for nodes in such a container. html-to-image uses these values for the export dimensions, so the resulting canvas was 0×0 or broken and the poster image + QR code did not appear. On desktop the same layout sometimes still reported dimensions, which is why it worked on PC but not on mobile.

## Solution
Pass explicit dimensions to `toPng()` so the library uses fixed 1080×1920 for the export regardless of the template's measured size. The poster and QR code now render correctly on mobile.

Made with [Cursor](https://cursor.com)