### PR TITLE
PWA: direct share to native apps via Web Share API

### DIFF
--- a/app/javascript/controllers/share_controller.js
+++ b/app/javascript/controllers/share_controller.js
@@ -18,8 +18,9 @@ export default class extends Controller {
     this.posterGenerated = false
   }
 
-  open() {
+  async open() {
     if (navigator.share) {
+      if (!this.posterGenerated) await this.generatePoster()
       this.webShare()
       return
     }


### PR DESCRIPTION
## Summary
When `navigator.share` is available (PWA / mobile), the share action now directly triggers the native share sheet instead of showing the poster dialog first.

## Changes
- **open()**: If Web Share API is supported, immediately call `webShare()` and skip the poster dialog
- **webShare()**: Include poster image as a `File` when already generated (for future dialog flow)
- Suppress `AbortError` in error handling (user cancelled share)

Made with [Cursor](https://cursor.com)