### PR TITLE
fix: footer mobile layout (#34)

### DIFF
--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,6 +1,6 @@
 <footer id="footer" class="max-w-6xl mx-auto px-4 py-2 mt-8">
-    <div class="flex justify-between items-center text-sm text-gray-600 dark:text-gray-400">
-        <div class="flex gap-2">
+    <div class="flex flex-col sm:flex-row sm:justify-between sm:items-center text-sm text-gray-600 gap-2 sm:gap-0">
+        <div class="flex gap-2 flex-wrap">
             <span>Version:</span> <%= app_version_badge %>
             <span>Git Revision:</span> <%= git_revision_badge %>
         </div>


### PR DESCRIPTION
## 修复内容

修复 iPhone 12 Pro 上 footer 换行问题。

### 修改

- 移动端使用 （垂直排列），sm+ 屏幕使用 （水平排列）
- 添加  防止小屏幕溢出

---

Fixes #34